### PR TITLE
Create prompt_task_map.json

### DIFF
--- a/doc/prompt_task_map.json
+++ b/doc/prompt_task_map.json
@@ -1,31 +1,83 @@
 {
     "commonsense_qa": [
-        "task073_commonsenseqa_answer_generation"
+        {
+            "task": "task073_commonsenseqa_answer_generation",
+            "prompt": [
+                "most_suitable_answer",
+				"question_answering",
+				"question_to_answer_index"
+            ]
+        }
     ],
     "dream": [
-        "task247_dream_answer_generation"
+        {
+            "task": "task247_dream_answer_generation",
+            "prompt": [
+                "baseline",
+				"read_the_following_conversation_and_answer_the_question"
+            ]
+        }
     ],
     "quail": [
-		"task887_quail_answer_generation"
+        {
+            "task": "task887_quail_answer_generation",
+            "prompt": [
+                "context_description_question_text",
+				"context_question_description_text",
+				"description_context_question_text"
+            ]
+        }
     ],
     "quartz": [
     ],
     "social_i_qa": [
-        "task384_socialiqa_question_classification",
-		"task580_socialiqa_answer_generation"
+        {
+            "task": "task384_socialiqa_question_classification",
+            "prompt": [
+				"Check if a random answer is valid or not"
+            ]
+        },
+        {
+            "task": "task580_socialiqa_answer_generation",
+            "prompt": [
+				"Show choices and generate answer",
+				"Show choices and generate index"
+            ]
+        }
     ],
     "wiqa": [
     ],
     "cosmos_qa": [
-        "task024_cosmosqa_answer_generation"
+        {
+            "task": "task024_cosmosqa_answer_generation",
+            "prompt": [
+				"context_description_question_text",
+				"context_question_description_text",
+				"description_context_question_text"
+            ]
+        }
     ],
     "qasc": [
     ],
     "quarel": [
-        "task1378_quarel_correct_answer_generation"
+        {
+            "task": "task1378_quarel_correct_answer_generation",
+            "prompt": [
+				"choose_between",
+				"do_not_use",
+				"heres_a_story",
+				"logic_test",
+				"testing_students"
+            ]
+        }
     ],
     "sciq": [
-        "task591_sciq_answer_generation"
+        {
+            "task": "task591_sciq_answer_generation",
+            "prompt": [
+				"Direct Question (Closed Book)"
+            ]
+        }
     ],
     "wiki_hop/original": [
     ],
@@ -40,90 +92,349 @@
     "adversarial_qa/droberta": [
     ],
     "quoref": [
-        "task002_quoref_answer_generation"
+        {
+            "task": "task002_quoref_answer_generation",
+            "prompt": [
+				"Answer Friend Question",
+				"Answer Question Given Context",
+				"Answer Test",
+				"Context Contains Answer",
+				"Find Answer",
+				"Found Context Online",
+				"Given Context Answer Question",
+				"Guess Answer",
+				"Read And Extract",
+				"What Is The Answer"
+            ]
+        }
     ],
     "duorc/SelfRC": [
-        "task194_duorc_answer_generation",
-		"task193_duorc_question_generation"
+        {
+            "task": "task193_duorc_question_generation",
+            "prompt": [
+				"generate_question"
+            ]
+        },
+        {
+            "task": "task194_duorc_answer_generation",
+            "prompt": [
+				"answer_question",
+				"decide_worth_it",
+				"question_answering",
+				"movie_director",
+				"extract_answer"
+            ]
+        }
     ],
     "duorc/ParaphraseRC": [
-        "task194_duorc_answer_generation",
-		"task193_duorc_question_generation"
+        {
+            "task": "task193_duorc_question_generation",
+            "prompt": [
+				"generate_question"
+            ]
+        },
+        {
+            "task": "task194_duorc_answer_generation",
+            "prompt": [
+				"answer_question",
+				"decide_worth_it",
+				"question_answering",
+				"movie_director",
+				"extract_answer"
+            ]
+        }
     ],
     "ropes": [
-        "task061_ropes_answer_generation"
+        {
+            "task": "task061_ropes_answer_generation",
+            "prompt": [
+				"background_new_situation_answer",
+				"background_situation_middle",
+				"given_background_situation",
+				"new_situation_background_answer",
+				"plain_background_situation",
+				"plain_bottom_hint",
+				"prompt_beginning",
+				"prompt_bottom_hint_beginning",
+				"prompt_mix",
+				"read_background_situation"
+            ]
+        }
     ],
     "hotpot_qa/distractor": [
-        "task170_hotpotqa_answer_generation",
-		"task192_hotpotqa_sentence_generation",
-		"task191_hotpotqa_question_generation"
+        {
+            "task": "task170_hotpotqa_answer_generation",
+            "prompt": [
+				"generate_answer_affirmative",
+				"generate_answer_interrogative"
+            ]
+        },
+        {
+            "task": "task191_hotpotqa_question_generation",
+            "prompt": [
+				"generate_question"
+            ]
+        },
+        {
+            "task": "task192_hotpotqa_sentence_generation",
+            "prompt": [
+				"generate_explanations_affirmative",
+				"generate_explanations_interrogative"
+            ]
+        }
     ],
     "hotpot_qa/fullwiki": [
-        "task170_hotpotqa_answer_generation",
-		"task192_hotpotqa_sentence_generation",
-		"task191_hotpotqa_question_generation"
+        {
+            "task": "task170_hotpotqa_answer_generation",
+            "prompt": [
+				"generate_answer_affirmative",
+				"generate_answer_interrogative"
+            ]
+        },
+        {
+            "task": "task191_hotpotqa_question_generation",
+            "prompt": [
+				"generate_question"
+            ]
+        },
+        {
+            "task": "task192_hotpotqa_sentence_generation",
+            "prompt": [
+				"generate_explanations_affirmative",
+				"generate_explanations_interrogative"
+            ]
+        }
     ],
     "wiki_qa": [
     ],
     "common_gen": [
-        "task102_commongen_sentence_generation"
+        {
+            "task": "task102_commongen_sentence_generation",
+            "prompt": [
+				"Example prompt",
+				"Given concepts - type 2",
+				"Given concepts type 1",
+				"Put together",
+				"choice in concept centric sentence generation",
+				"random task template prompt"
+            ]
+        }
     ],
     "wiki_bio": [
     ],
     "amazon_polarity": [
-        "task493_review_polarity_classification"
+        {
+            "task": "task493_review_polarity_classification",
+            "prompt": [
+				"User_recommend_this_product"
+            ]
+        }
     ],
     "amazon_reviews_multi/en": [
-        "task618_amazonreview_summary_text_generation",
-		"task1310_amazonreview_rating_classification",
-		"task617_amazonreview_category_text_generation"
+        {
+            "task": "task617_amazonreview_category_text_generation",
+            "prompt": [
+				"prompt_review_to_category"            ]
+        },
+        {
+            "task": "task618_amazonreview_summary_text_generation",
+            "prompt": [
+				"generate_title"
+            ]
+        },
+        {
+            "task": "task1310_amazonreview_rating_classification",
+            "prompt": [
+				"prompt_body_title_to_star",
+				"prompt_review_to_star"
+            ]
+        }
     ],
     "amazon_us_reviews/Wireless_v1_00": [
-        "task1342_amazon_us_reviews_title"
+        {
+            "task": "task1342_amazon_us_reviews_title",
+            "prompt": [
+				"Generate review headline based on review body"
+            ]
+        }
     ],
     "imdb": [
-        "task284_imdb_classification"
+        {
+            "task": "task284_imdb_classification",
+            "prompt": [
+				"Movie Expressed Sentiment",
+				"Movie Expressed Sentiment 2",
+				"Reviewer Enjoyment",
+				"Reviewer Enjoyment Yes No",
+				"Reviewer Expressed Sentiment",
+				"Reviewer Opinion bad good choices",
+				"Reviewer Sentiment Feeling",
+				"Sentiment with choices",
+				"Text Expressed Sentiment",
+				"Writer Expressed Sentiment"
+            ]
+        }
     ],
     "rotten_tomatoes": [
-        "task888_reviews_classification"
+        {
+            "task": "task888_reviews_classification",
+            "prompt": [
+				"Movie Expressed Sentiment",
+				"Movie Expressed Sentiment 2",
+				"Reviewer Enjoyment",
+				"Reviewer Enjoyment Yes No",
+				"Reviewer Expressed Sentiment",
+				"Reviewer Opinion bad good choices",
+				"Reviewer Sentiment Feeling",
+				"Sentiment with choices",
+				"Text Expressed Sentiment",
+				"Writer Expressed Sentiment"
+            ]
+        }
     ],
     "yelp_polarity": [
-        "task475_yelp_polarity_classification"
+        {
+            "task": "task475_yelp_polarity_classification",
+            "prompt": [
+				"come_again",
+				"experience_good_bad",
+				"format_come_again",
+				"format_good_bad",
+				"like_dislike",
+				"like_dislike_2",
+				"place_good_bad",
+				"rating_high_low",
+				"regret_yes_or_no"
+            ]
+        }
     ],
     "yelp_review_full": [
     ],
     "cnn_dailymail/3.0.0": [
-        "task1553_cnn_dailymail_summarization"
+        {
+            "task": "task1553_cnn_dailymail_summarization",
+            "prompt": [
+				"2_or_3_sentences",
+				"news_card_view",
+				"news_stock",
+				"news_summary",
+				"sum_in_brief",
+				"tldr_summary",
+				"write_an_outline"
+            ]
+        }
     ],
     "gigaword": [
-        "task288_gigaword_summarization"
+        {
+            "task": "task288_gigaword_summarization",
+            "prompt": [
+				"TLDR",
+				"first_sentence_title",
+				"generate_summary_for_this",
+				"in_a_nutshell",
+				"make_a_title",
+				"write_a_title_for_this_sentence",
+				"write_its_sentence"
+            ]
+        }
     ],
     "multi_news": [
     ],
     "samsum": [
-        "task1572_samsum_summary"
+        {
+            "task": "task1572_samsum_summary",
+            "prompt": [
+				"Generate a summary for this dialogue",
+				"Given the above dialogue write a summary",
+				"Sum up the following dialogue",
+				"Summarize this dialogue:",
+				"To sum up this dialog",
+				"Summarize:"
+            ]
+        }
     ],
     "xsum": [
     ],
     "ag_news": [
-        "task1541_agnews_classification"
+        {
+            "task": "task1541_agnews_classification",
+            "prompt": [
+				"classify",
+				"classify_question_first",
+				"classify_with_choices",
+				"classify_with_choices_question_first",
+				"recommend",
+				"which_section",
+				"which_section_choices"
+            ]
+        }
     ],
     "dbpedia_14": [
-        "task629_dbpedia_14_classification",
-		"task633_dbpedia_14_answer_generation"
+        {
+            "task": "task629_dbpedia_14_classification",
+            "prompt": [
+				"given_list_what_category_does_the_paragraph_belong_to",
+				"pick_one_category_for_the_following_text"
+            ]
+        }
     ],
     "trec": [
     ],
     "glue/mrpc": [
     ],
     "paws/labeled_final": [
-        "task400_paws_paraphrase_classification"
+        {
+            "task": "task400_paws_paraphrase_classification",
+            "prompt": [
+				"Concatenation",
+				"Concatenation-no-label",
+				"Meaning",
+				"Meaning-no-label",
+				"PAWS-ANLI GPT3",
+				"PAWS-ANLI GPT3-no-label",
+				"Rewrite",
+				"Rewrite-no-label",
+				"context-question",
+				"context-question-no-label",
+				"task_description-no-label"
+            ]
+        }
     ],
     "paws/labeled_swap": [
-        "task400_paws_paraphrase_classification"
+        {
+            "task": "task400_paws_paraphrase_classification",
+            "prompt": [
+				"Concatenation",
+				"Concatenation-no-label",
+				"Meaning",
+				"Meaning-no-label",
+				"PAWS-ANLI GPT3",
+				"PAWS-ANLI GPT3-no-label",
+				"Rewrite",
+				"Rewrite-no-label",
+				"context-question",
+				"context-question-no-label",
+				"task_description-no-label"
+            ]
+        }
     ],
     "paws/unlabeled_final": [
-        "task400_paws_paraphrase_classification"
+        {
+            "task": "task400_paws_paraphrase_classification",
+            "prompt": [
+				"Concatenation",
+				"Concatenation-no-label",
+				"Meaning",
+				"Meaning-no-label",
+				"PAWS-ANLI GPT3",
+				"PAWS-ANLI GPT3-no-label",
+				"Rewrite",
+				"Rewrite-no-label",
+				"context-question",
+				"context-question-no-label",
+				"task_description-no-label"
+            ]
+        }
     ],
     "glue/qqp": [
     ]

--- a/doc/prompt_task_map.json
+++ b/doc/prompt_task_map.json
@@ -359,12 +359,8 @@
         {
             "task": "task1541_agnews_classification",
             "prompt": [
-				"classify",
-				"classify_question_first",
 				"classify_with_choices",
 				"classify_with_choices_question_first",
-				"recommend",
-				"which_section",
 				"which_section_choices"
             ]
         }
@@ -437,5 +433,314 @@
         }
     ],
     "glue/qqp": [
+    ],
+    "ai2_arc/ARC-Challenge": [
+        {
+            "task": "task229_arc_answer_generation_hard",
+            "prompt": [
+				"heres_a_problem",
+				"i_am_hesitating",
+				"multiple_choice",
+				"pick_the_most_correct_option",
+				"qa_options"
+            ]
+        }
+    ],
+    "ai2_arc/ARC-Easy": [
+        {
+            "task": "task228_arc_answer_generation_easy",
+            "prompt": [
+				"heres_a_problem",
+				"i_am_hesitating",
+				"multiple_choice",
+				"pick_the_most_correct_option",
+				"qa_options"
+            ]
+        }
+    ],
+    "openbookqa/additional": [
+    ],
+    "openbookqa/main": [
+    ],
+    "piqa": [
+        {
+            "task": "task080_piqa_answer_generation",
+            "prompt": [
+				"no prompt needed"
+            ]
+        }
+    ],
+    "race/all": [
+        {
+            "task": "task309_race_answer_generation",
+            "prompt": [
+				"Select the best answer",
+				"Select the best answer (generate span)",
+				"Select the best answer (no instructions)",
+				"Taking a test"
+            ]
+        }
+    ],
+    "race/high": [
+        {
+            "task": "task309_race_answer_generation",
+            "prompt": [
+				"Select the best answer",
+				"Select the best answer (generate span)",
+				"Select the best answer (no instructions)",
+				"Taking a test"
+            ]
+        }
+    ],
+    "race/middle": [
+        {
+            "task": "task309_race_answer_generation",
+            "prompt": [
+				"Select the best answer",
+				"Select the best answer (generate span)",
+				"Select the best answer (no instructions)",
+				"Taking a test"
+            ]
+        }
+    ],
+    "hellaswag": [
+        {
+            "task": "task1389_hellaswag_completion",
+            "prompt": [
+				"Randomized prompts template",
+				"complete_first_then",
+				"how_ends",
+				"if_begins_how_continues"
+            ]
+        }
+    ],
+    "squad_v2": [
+        {
+            "task": "task349_squad2.0_answerable_unanswerable_question_classification",
+            "prompt": [
+				"Unanwerable question"
+            ]
+        }
+    ],
+    "trivia_qa/unfiltered": [
+        {
+            "task": "task1564_triviaqa_answer_generation",
+            "prompt": [
+				"first_person_context",
+				"formal_description",
+				"question_answer",
+				"question_with_instruction"
+            ]
+        }
+    ],
+    "web_questions": [
+    ],
+    "super_glue/boolq": [
+        {
+            "task": "task380_boolq_yes_no_question",
+            "prompt": [
+				"GPT-3 Style",
+				"I wonder…",
+				"after_reading",
+				"based on the following passage",
+				"based on the previous passage",
+				"could you tell me…",
+				"exam",
+				"exercise",
+				"valid_binary",
+				"yes_no_question"
+            ]
+        }
+    ],
+    "super_glue/copa": [
+    ],
+    "super_glue/multirc": [
+    ],
+    "super_glue/record": [
+        {
+            "task": "task302_record_classification",
+            "prompt": [
+				"trying_to_decide",
+				"pick_one_option",
+				"choose_between",
+				"Which one is the placeholder?",
+				"What could the placeholder be?"
+            ]
+        },
+        {
+            "task": "task339_record_answer_generation",
+            "prompt": [
+				"the placeholder refers to…",
+				"exercise",
+				"corrupted",
+				"In the question above, the placeholder stands for",
+				"Can you figure out…"
+            ]
+        }
+    ],
+    "super_glue/wic": [
+        {
+            "task": "task625_xlwic_true_or_false_answer_generation",
+            "prompt": [
+				"GPT-3-prompt",
+				"GPT-3-prompt-with-label",
+				"affirmation_true_or_false",
+				"grammar_homework",
+				"polysemous",
+				"question-context",
+				"question-context-meaning",
+				"Generalized question-context format with label",
+				"same_sense",
+				"similar-sense"
+            ]
+        }
+    ],
+    "super_glue/wsc.fixed": [
+        {
+            "task": "task1390_wscfixed_coreference",
+            "prompt": [
+				"GPT-3 Style",
+				"I think they mean",
+				"Who or what is/are",
+				"by p they mean",
+				"does p stand for",
+				"does the pronoun refer to",
+				"in other words",
+				"p is/are r",
+				"replaced with",
+				"the pronoun refers to"
+            ]
+        }
+    ],
+    "anli": [
+        {
+            "task": "task1385_anli_r1_entailment",
+            "prompt": [
+				"GPT-3 style",
+				"MNLI crowdsource",
+				"always/sometimes/never",
+				"based on the previous passage",
+				"can we infer",
+				"claim true/false/inconclusive",
+				"consider always/sometimes/never",
+				"does it follow that",
+				"does this imply",
+				"guaranteed true",
+				"guaranteed/possible/impossible",
+				"justified in saying",
+				"must be true",
+				"should assume",
+				"take the following as truth"
+            ]
+        },
+        {
+            "task": "task1386_anli_r2_entailment",
+            "prompt": [
+				"GPT-3 style",
+				"MNLI crowdsource",
+				"always/sometimes/never",
+				"based on the previous passage",
+				"can we infer",
+				"claim true/false/inconclusive",
+				"consider always/sometimes/never",
+				"does it follow that",
+				"does this imply",
+				"guaranteed true",
+				"guaranteed/possible/impossible",
+				"justified in saying",
+				"must be true",
+				"should assume",
+				"take the following as truth"
+            ]
+        },
+        {
+            "task": "task1387_anli_r3_entailment",
+            "prompt": [
+				"GPT-3 style",
+				"MNLI crowdsource",
+				"always/sometimes/never",
+				"based on the previous passage",
+				"can we infer",
+				"claim true/false/inconclusive",
+				"consider always/sometimes/never",
+				"does it follow that",
+				"does this imply",
+				"guaranteed true",
+				"guaranteed/possible/impossible",
+				"justified in saying",
+				"must be true",
+				"should assume",
+				"take the following as truth"
+            ]
+        }
+    ],
+    "super_glue/cb": [
+        {
+            "task": "task1388_cb_entailment",
+            "prompt": [
+				"GPT-3 style",
+				"MNLI crowdsource",
+				"always/sometimes/never",
+				"based on the previous passage",
+				"can we infer",
+				"claim true/false/inconclusive",
+				"consider always/sometimes/never",
+				"does it follow that",
+				"does this imply",
+				"guaranteed true",
+				"guaranteed/possible/impossible",
+				"justified in saying",
+				"must be true",
+				"should assume",
+				"take the following as truth"
+            ]
+        }
+    ],
+    "glue/rte": [
+        {
+            "task": "task1344_glue_entailment_classification",
+            "prompt": [
+				"does the claim… follow the fact…",
+				"entailment explained",
+				"imply",
+				"imply separated",
+				"mean"
+            ]
+        }
+    ],
+    "winogrande/winogrande_xl": [
+        {
+            "task": "task1391_winogrande_easy_answer_generation",
+            "prompt": [
+				"Replace",
+				"does underscore refer to",
+				"fill in the blank",
+				"stand for",
+				"underscore refer to"
+            ]
+        }
+    ],
+    "winogrande/winogrande_xs": [
+    ],
+    "winogrande/winogrande_s": [
+    ],
+    "winogrande/winogrande_m": [
+    ],
+    "winogrande/winogrande_l": [
+    ],
+    "winogrande/winogrande_debiased": [
+    ],
+    "story_cloze/2016": [
+        {
+            "task": "task296_storycloze_correct_end_classification",
+            "prompt": [
+				"Answer Given options",
+				"Choose Story Ending",
+				"Movie What Happens Next",
+				"Story Continuation and Options",
+				"Generate Ending",
+				"Novel Correct Ending"
+            ]
+        }
     ]
 }

--- a/doc/prompt_task_map.json
+++ b/doc/prompt_task_map.json
@@ -161,6 +161,8 @@
             ]
         }
     ],
+    "kilt_tasks/hotpotqa": [
+	],
     "hotpot_qa/distractor": [
         {
             "task": "task170_hotpotqa_answer_generation",
@@ -708,7 +710,7 @@
             ]
         }
     ],
-    "winogrande/winogrande_xl": [
+    "winogrande/winogrande_debiased": [
         {
             "task": "task1391_winogrande_easy_answer_generation",
             "prompt": [
@@ -719,16 +721,6 @@
 				"underscore refer to"
             ]
         }
-    ],
-    "winogrande/winogrande_xs": [
-    ],
-    "winogrande/winogrande_s": [
-    ],
-    "winogrande/winogrande_m": [
-    ],
-    "winogrande/winogrande_l": [
-    ],
-    "winogrande/winogrande_debiased": [
     ],
     "story_cloze/2016": [
         {

--- a/doc/prompt_task_map.json
+++ b/doc/prompt_task_map.json
@@ -1,0 +1,130 @@
+{
+    "commonsense_qa": [
+        "task073_commonsenseqa_answer_generation"
+    ],
+    "dream": [
+        "task247_dream_answer_generation"
+    ],
+    "quail": [
+		"task887_quail_answer_generation"
+    ],
+    "quartz": [
+    ],
+    "social_i_qa": [
+        "task384_socialiqa_question_classification",
+		"task580_socialiqa_answer_generation"
+    ],
+    "wiqa": [
+    ],
+    "cosmos_qa": [
+        "task024_cosmosqa_answer_generation"
+    ],
+    "qasc": [
+    ],
+    "quarel": [
+        "task1378_quarel_correct_answer_generation"
+    ],
+    "sciq": [
+        "task591_sciq_answer_generation"
+    ],
+    "wiki_hop/original": [
+    ],
+    "wiki_hop/masked": [
+    ],
+    "adversarial_qa/adversarialQA": [
+    ],
+    "adversarial_qa/dbidaf": [
+    ],
+    "adversarial_qa/dbert": [
+    ],	
+    "adversarial_qa/droberta": [
+    ],
+    "quoref": [
+        "task002_quoref_answer_generation"
+    ],
+    "duorc/SelfRC": [
+        "task194_duorc_answer_generation",
+		"task193_duorc_question_generation"
+    ],
+    "duorc/ParaphraseRC": [
+        "task194_duorc_answer_generation",
+		"task193_duorc_question_generation"
+    ],
+    "ropes": [
+        "task061_ropes_answer_generation"
+    ],
+    "hotpot_qa/distractor": [
+        "task170_hotpotqa_answer_generation",
+		"task192_hotpotqa_sentence_generation",
+		"task191_hotpotqa_question_generation"
+    ],
+    "hotpot_qa/fullwiki": [
+        "task170_hotpotqa_answer_generation",
+		"task192_hotpotqa_sentence_generation",
+		"task191_hotpotqa_question_generation"
+    ],
+    "wiki_qa": [
+    ],
+    "common_gen": [
+        "task102_commongen_sentence_generation"
+    ],
+    "wiki_bio": [
+    ],
+    "amazon_polarity": [
+        "task493_review_polarity_classification"
+    ],
+    "amazon_reviews_multi/en": [
+        "task618_amazonreview_summary_text_generation",
+		"task1310_amazonreview_rating_classification",
+		"task617_amazonreview_category_text_generation"
+    ],
+    "amazon_us_reviews/Wireless_v1_00": [
+        "task1342_amazon_us_reviews_title"
+    ],
+    "imdb": [
+        "task284_imdb_classification"
+    ],
+    "rotten_tomatoes": [
+        "task888_reviews_classification"
+    ],
+    "yelp_polarity": [
+        "task475_yelp_polarity_classification"
+    ],
+    "yelp_review_full": [
+    ],
+    "cnn_dailymail/3.0.0": [
+        "task1553_cnn_dailymail_summarization"
+    ],
+    "gigaword": [
+        "task288_gigaword_summarization"
+    ],
+    "multi_news": [
+    ],
+    "samsum": [
+        "task1572_samsum_summary"
+    ],
+    "xsum": [
+    ],
+    "ag_news": [
+        "task1541_agnews_classification"
+    ],
+    "dbpedia_14": [
+        "task629_dbpedia_14_classification",
+		"task633_dbpedia_14_answer_generation"
+    ],
+    "trec": [
+    ],
+    "glue/mrpc": [
+    ],
+    "paws/labeled_final": [
+        "task400_paws_paraphrase_classification"
+    ],
+    "paws/labeled_swap": [
+        "task400_paws_paraphrase_classification"
+    ],
+    "paws/unlabeled_final": [
+        "task400_paws_paraphrase_classification"
+    ],
+    "glue/qqp": [
+    ]
+}


### PR DESCRIPTION
Here is the map of the shared task between our tasks and training datasets of the T0 model.
They have trained the model on the 35 datasets. We have 31 shared tasks and lots of missing tasks that I've listed in the spreadsheet.
Also, for the paws, duorc, amazon_us_reviews, and hotpotqa datasets, our tasks don't have a specific subset. So, we may need to add them again.


