### PR TITLE
Fix arg name at rouge

### DIFF
--- a/eval/automatic/evaluation.py
+++ b/eval/automatic/evaluation.py
@@ -10,7 +10,7 @@ def rouge(prediction, ground_truth):
     score = rouge_metric.compute(
         predictions=[prediction],
         references=[ground_truth],
-        **{'use_agregator': False, 'use_stemmer': True, 'rouge_types': ['rougeL']}
+        **{'use_aggregator': False, 'use_stemmer': True, 'rouge_types': ['rougeL']}
     )
     return score['rougeL'][0].fmeasure
 


### PR DESCRIPTION
Fixed argument name `use_agregator` to `use_aggregator`

Reference: https://github.com/huggingface/datasets/blob/master/metrics/rouge/rouge.py#L65