### PR TITLE
correct the link to create_reference_file.py

### DIFF
--- a/eval/automatic/README.md
+++ b/eval/automatic/README.md
@@ -17,7 +17,7 @@ Then, you can evaluate your prediction output as follows:
 python evaluation.py --prediction_file=predictions.jsonl --reference_file=references.jsonl
 ```
 
-Each line of `predictions.jsonl` should correspond to a json object that contains `id` and `prediction` fields. `reference.jsonl` should have `id`, `references`, `task_id`, `task_category` and `track` in each line. To produce the reference file of our official test set, you can run the script in [`eval/automatic/leaderboard/create_reference_file.py`](eval/automatic/leaderboard/create_reference_file.py) as follows:
+Each line of `predictions.jsonl` should correspond to a json object that contains `id` and `prediction` fields. `reference.jsonl` should have `id`, `references`, `task_id`, `task_category` and `track` in each line. To produce the reference file of our official test set, you can run the script in [`eval/automatic/leaderboard/create_reference_file.py`](eval/leaderboard/create_reference_file.py) as follows:
 
 ```bash
 python eval/automatic/leaderboard/create_reference_file.py


### PR DESCRIPTION
The link to ```create_reference_file.py``` in the file ```eval/automatic/README.md``` is outdated. I changed it to the right place.